### PR TITLE
Updates to API calls, tabContents

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -19,44 +19,46 @@ import Tabs from './components/main/tabs/Tabs';
 import Footer from './components/Footer.js';
 
 function App() {
-  
+  const apiBaseURL = "https://www.dnd5eapi.co";
+  const apiRacesURL = "https://www.dnd5eapi.co/api/races/";
   // Setting states
   const [userChoice, setUserChoice] = useState('');
-  
   const [accordionData, setAccordionData] = useState({});
   const [race, setRace] = useState('');
   const [traitsArray, setTraitsArray] = useState([]);
-  const [subracesArray, setSubracesArray] = useState([])
-  const [proficienciesArray, setProficienciesArray] = useState([])
+  const [proficienciesArray, setProficienciesArray] = useState([]);
+  const [subracesArray, setSubracesArray] = useState([]);
 
   return (
     <div className="App">
       <div className="wrapper body-flex-center">
-        <ApiDataContext.Provider
-          value={
+          <ApiDataContext.Provider
+            value={
             {
-              accordionData,
-              traitsArray,
-              subracesArray,
-              proficienciesArray, 
-              setAccordionData,
-              setTraitsArray,
-              setSubracesArray,
-              setProficienciesArray,
-              setRace
+                apiBaseURL,
+                apiRacesURL,
+                accordionData,
+                traitsArray,
+                proficienciesArray,
+                subracesArray,
+                setAccordionData,
+                setTraitsArray,
+                setProficienciesArray,
+                setSubracesArray,
+                setRace
+              }
             }
-          }
-        >
-          <Header>
-            <Form
-              userChoice={userChoice}
-              setUserChoice={setUserChoice}
-            />
-          </Header>
-          <Main race={race}>  
-            <Tabs race={race} />
-          </Main>
-        </ApiDataContext.Provider>
+          >
+            <Header>
+              <Form
+                userChoice={userChoice}
+                setUserChoice={setUserChoice}
+              />
+            </Header>
+            <Main race={race}>  
+              <Tabs race={race} />
+            </Main>
+          </ApiDataContext.Provider>
       </div>
       <Footer />
     </div>

--- a/src/components/header/Form.js
+++ b/src/components/header/Form.js
@@ -5,12 +5,11 @@ import { ApiDataContext } from "../../Contexts/ApiDataContext";
 const Form = ({ userChoice, setUserChoice }) => {
 
     const [selectOptions, setSelectOptions] = useState([]);
-    const {setAccordionData, setTraitsArray, setSubracesArray, setProficienciesArray, setRace} = useContext(ApiDataContext)
-      // API call attached to a submit event on the Form.js component, that calls a specific race's endpoint and updates a number of states
+    const { apiRacesURL, setAccordionData, setTraitsArray,setSubracesArray, setProficienciesArray, setRace } = useContext(ApiDataContext)
     
-    const generalDataApiCall = (endpoint) => {
+    const generalDataApiCall = (userChoice) => {
         axios({
-            url: `https://www.dnd5eapi.co/api/races/${endpoint}`,
+            url: `${apiRacesURL}${userChoice}`,
             method: "GET",
             dataResponse: "json"
         }).then((response) => {
@@ -18,50 +17,36 @@ const Form = ({ userChoice, setUserChoice }) => {
                 age: response.data.age,
                 alignment: response.data.alignment,
                 size: response.data.size_description,
-                language: response.data.language_desc 
+                language: response.data.language_desc
             })
             setRace(response.data.index)
             setTraitsArray(response.data.traits)
-        })
-    }
-
-    const subracesDataApiCall = (endpoint) => {
-        axios({
-            url: `https://www.dnd5eapi.co/api/races/${endpoint}/subraces`,
-            method: "GET",
-            dataResponse: "json"
-            }).then((response) => {
-                setSubracesArray(response.data.results);
-            })
-    }
-
-    const proficienciesDataApiCall = (endpoint) => {
-        axios({
-            url: `https://www.dnd5eapi.co/api/races/${endpoint}/proficiencies`,
-            method: "GET",
-            dataResponse: "json"
-            }).then((response) => {
-                setProficienciesArray(response.data.results);
-            })
+            setProficienciesArray(response.data.starting_proficiencies)
+            setSubracesArray(response.data.subraces)
+        }).catch(error => {
+            alert('Oops! Something went wrong!')
+            return error
+        });
     }
     
     const handleFormSubmit = (e) => {
         e.preventDefault();
         generalDataApiCall(userChoice)
-        subracesDataApiCall(userChoice)
-        proficienciesDataApiCall(userChoice)
     }
         
-        // FIrst API call, on App.js component mount, to get the array of races that will populate the Select element in the Form's JSX
+    // FIrst API call, on App.js component mount, to get the array of races that will populate the Select element in the Form's JSX
     useEffect(() => {
         axios({
-            url: "https://www.dnd5eapi.co/api/races/",
+            url: apiRacesURL,
             method: "GET",
             dataResponse: "json"
         }).then((response) => { 
             setSelectOptions(response.data.results);
+        }).catch(error => {
+            alert('Oops! Something went wrong!')
+            return error
         });
-    }, [])
+    }, [apiRacesURL])
 
     return (
         <>

--- a/src/components/main/Image.js
+++ b/src/components/main/Image.js
@@ -1,5 +1,5 @@
 const Image = ( {race} ) => {
-    // TODO: Figure out why this is trying to load when userChoice changes instead of when index changes
+    // TODO: Add a loading state so that the image changing over isn't so jarring
     return (
         <div className="race-image">
             {/* Join the raceIndex string to the path for the public folder in order to dynamically update the img src attribute. The reason to use raceIndex and not userChoice, is that userChoice updates on option change (ie as soon as someone clicks an option in the dropdown), whereas raceIndex only updates after form submission, which is what we want */}

--- a/src/components/main/Main.js
+++ b/src/components/main/Main.js
@@ -4,15 +4,15 @@ const Main = ({ race, children }) => {
     return(
         <main>
                 {
-                    race ? 
+                    race && 
                     <>
                         <div className="main-flex-container">
                             <Image race={race} />
                             <h2>{race}</h2>
                         </div>
                             {children}
-                        </>
-                    : <p className="summary">Select a race from the dropdown to view some of their characteristics from the 5th Edition of Dungeons and Dragons!</p>
+                    </>
+                    // alternative to use a ternary operation to check for the race state and show this if it's falsy:  <p className="summary">Select a race from the dropdown to view some of their characteristics from the 5th Edition of Dungeons and Dragons!</p>
                 }
         </main>
     )

--- a/src/components/main/accordions/AccordionItem.js
+++ b/src/components/main/accordions/AccordionItem.js
@@ -2,14 +2,22 @@ import { AccordionToggleContext } from "../../../Contexts/AccordionToggleContext
 import { useContext } from "react";
 
 const AccordionItem = ({ heading, text, index }) => {
-    const {toggle, selected} = useContext(AccordionToggleContext)
+    const { toggle, selected } = useContext(AccordionToggleContext)
+    //TODO: All of the individual Accordion items except for General are now basically the same! Time to refactor to a reusable component instead
     return (
         <>
-            <div className="accordion-heading" onClick={() => toggle(index)}>
+            <div
+                className="accordion-heading"
+                onClick={() => toggle(index)}
+            >
                 <h3>{heading}</h3> 
                 <span>{selected === index ? '-' : '+'}</span>
             </div>
-            <div className={selected === index ? 'accordion-details show' : 'accordion-details'}>
+            <div
+                className={selected === index ?
+                    'accordion-details show'
+                    : 'accordion-details'}
+            >
                 <p>{text}</p>                
             </div>
         </>

--- a/src/components/main/accordions/Proficiency.js
+++ b/src/components/main/accordions/Proficiency.js
@@ -1,19 +1,24 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useContext } from 'react';
 import axios from 'axios';
 import AccordionItem from '../accordions/AccordionItem';
+import { ApiDataContext } from '../../../Contexts/ApiDataContext';
 
 const Proficiency = ({ url, index }) => {
+    const { apiBaseURL } = useContext(ApiDataContext);
     const [apiResponse, setApiResponse] = useState('')
 
     useEffect(() => {
         axios({
-            url: `https://www.dnd5eapi.co${url}`,
+            url: `${apiBaseURL}${url}`,
             method: 'GET',
             dataResponse: 'json'
         }).then((response) => {
             setApiResponse(response.data.name);
+        }).catch(error => {
+            alert('Oops! Something went wrong!')
+            return error
         });
-    }, [url])
+    }, [apiBaseURL, url])
 
     return (
         <>

--- a/src/components/main/accordions/Subrace.js
+++ b/src/components/main/accordions/Subrace.js
@@ -1,8 +1,10 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useContext } from 'react';
 import axios from 'axios';
+import { ApiDataContext } from '../../../Contexts/ApiDataContext';
 import AccordionItem from '../accordions/AccordionItem';
 
-const Subrace = ({url, index}) => {
+const Subrace = ({ url, index }) => {
+    const { apiBaseURL } = useContext(ApiDataContext);
     const [apiResponse, setApiResponse] = useState({
         desc: [], 
         name: ''
@@ -10,7 +12,7 @@ const Subrace = ({url, index}) => {
 
     useEffect(() => {
         axios({
-            url: `https://www.dnd5eapi.co${url}`,
+            url: `${apiBaseURL}${url}`,
             method: 'GET',
             dataResponse: 'json'
         }).then((response) => {
@@ -18,8 +20,11 @@ const Subrace = ({url, index}) => {
                 desc: response.data.desc,
                 name: response.data.name
             });
+        }).catch(error => {
+            alert('Oops! Something went wrong!')
+            return error
         });
-    }, [url])
+    }, [apiBaseURL, url])
 
     return (
         <>

--- a/src/components/main/accordions/Trait.js
+++ b/src/components/main/accordions/Trait.js
@@ -1,16 +1,18 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useContext } from 'react';
 import axios from 'axios';
+import { ApiDataContext } from '../../../Contexts/ApiDataContext';
 import AccordionItem from './AccordionItem';
 
-const Trait = ({url, index}) => {
+const Trait = ({ url, index }) => {
+    const { apiBaseURL } = useContext(ApiDataContext);
     const [traitResponse, setTraitResponse] = useState({
-        desc: [], 
+        desc: [],
         name: ''
-    })
+    });
 
     useEffect(() => {
         axios({
-            url: `https://www.dnd5eapi.co${url}`,
+            url: `${apiBaseURL}${url}`,
             method: 'GET',
             dataResponse: 'json'
         }).then((response) => {
@@ -18,8 +20,11 @@ const Trait = ({url, index}) => {
                 desc: response.data.desc,
                 name: response.data.name
             });
+        }).catch(error => {
+            alert('Oops! Something went wrong!')
+            return error
         });
-    }, [url])
+    }, [apiBaseURL, url])
 
     return (
         <>

--- a/src/components/main/tabs/TabContents.js
+++ b/src/components/main/tabs/TabContents.js
@@ -6,22 +6,12 @@ import Proficiencies from "../accordions/Proficiencies"
 const TabContents = ({ toggleActive }) => {
 
     const tabComponents = [<General />, <Traits />, <Subraces />, <Proficiencies />]
-
+    // TODO: Add a loading state to transition between each tab
     return(
         <div className="tabs-content">
             {
-                        tabComponents.map((component, i) => 
-                            <div
-                                key={i}
-                                className={
-                                toggleActive === i
-                                ? "content active-content"
-                                : "content"
-                            }>
-                                {component}
-                            </div>
-                        )
-                    }
+                tabComponents[toggleActive]
+            }
         </div>
     )
 }


### PR DESCRIPTION
- Reworked the API calls now that data for traits, subraces and proficiencies is coming in correctly from the main /races endpoint call. Also added some basic error handling, and created variables for two variations of the api URL to reduce repetition. 
- Changed tabContents so that they now only do their API calls when the tab is actually clicked on, however need to refine for cases where the user clicks to a different tab and then back to original one (it should store the data instead of having to do api calls each time)